### PR TITLE
MsLifetimeScope disposing fix

### DIFF
--- a/src/Castle.Windsor.MsDependencyInjection/WindsorServiceScope.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/WindsorServiceScope.cs
@@ -14,6 +14,8 @@ namespace Castle.Windsor.MsDependencyInjection
 
         private readonly IMsLifetimeScope _parentLifetimeScope;
 
+        private readonly IDisposable _msLifetimeScopeDisposable;
+
         public WindsorServiceScope(IWindsorContainer container, IMsLifetimeScope currentMsLifetimeScope)
         {
             _parentLifetimeScope = currentMsLifetimeScope;
@@ -22,15 +24,14 @@ namespace Castle.Windsor.MsDependencyInjection
 
             _parentLifetimeScope?.AddChild(LifetimeScope);
 
-            using (MsLifetimeScope.Using(LifetimeScope))
-            {
-                ServiceProvider = container.Resolve<IServiceProvider>();
-            }
+            _msLifetimeScopeDisposable = MsLifetimeScope.Using(LifetimeScope);
+            ServiceProvider = container.Resolve<IServiceProvider>();
         }
          
         public void Dispose()
         {
             _parentLifetimeScope?.RemoveChild(LifetimeScope);
+            _msLifetimeScopeDisposable?.Dispose();
             LifetimeScope.Dispose();
         }
     }


### PR DESCRIPTION
In some scenarios (namely using TypedFactoryFacility and resolving scoped component using Func<IScoped>) failed due to a missing `MsLifetimeScope.Current` which was released too early. 

If you wish to add a test for this scenario please feel free to get it from my [ContainerTest](https://github.com/pecanw/ContainerTest).