### PR TITLE
Wrap AddServices in an IWindsorInstaller to reduce registration/startup time

### DIFF
--- a/src/Castle.Windsor.MsDependencyInjection/WindsorRegistrationHelper.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/WindsorRegistrationHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Castle.MicroKernel.Registration;
+using Castle.MicroKernel.SubSystems.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceDescriptor = Microsoft.Extensions.DependencyInjection.ServiceDescriptor;
 
@@ -26,6 +27,11 @@ namespace Castle.Windsor.MsDependencyInjection
         /// Used to add services to an existing container, without creating a <see cref="IServiceProvider"/>.
         /// </summary>
         public static void AddServices(this IWindsorContainer container, IServiceCollection services)
+        {
+            container.Install(new ServiceCollectionInstaller(services));
+        }
+
+        internal static void AddServicesInternal(this IWindsorContainer container, IServiceCollection services)
         {
             AddBaseServices(container);
             AddSubResolvers(container);
@@ -171,6 +177,21 @@ namespace Castle.Windsor.MsDependencyInjection
             }
 
             return registrationBuilder;
+        }
+    }
+
+    internal sealed class ServiceCollectionInstaller : IWindsorInstaller
+    {
+        private readonly IServiceCollection _services;
+
+        public ServiceCollectionInstaller(IServiceCollection services)
+        {
+            _services = services;
+        }
+
+        public void Install(IWindsorContainer container, IConfigurationStore store)
+        {
+            container.AddServicesInternal(_services);
         }
     }
 }


### PR DESCRIPTION
All 3 methods called from AddServices are calling Register(..) one by one, leading to an exponential number of List/Set operations as a function of the number of implementations added. This is because every call can potentially trigger IKernelInternal.OptimizeDependencyResolution(), which in turn will iterate through all handlers in order to check and update the state if the handler now has every depedency satisfied. With this wrapper, the installer will be called by the container itself, deferring this check until all registrations are done.

On two big monolithic projects I have worked on that have lots of CQRS type handlers; a web API and a background eventhandler/processor, doing what amounts to the same change reduced the time spent by ApplicationHostBuilder.Build() more than 10x, previously approaching almost 2 minutes on developer machines, worse on CI/CD VMs.