### PR TITLE
Create a TargetFrameworks net5.0;net6.0;net7.0;net8.0

### DIFF
--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
@@ -17,11 +17,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.6.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.1.0</Version>
-    <TargetFramework>net6.0</TargetFramework>
-    <AssemblyName>Castle.Windsor.MsDependencyInjection.Tests</AssemblyName>
+    <Version>4.2.0</Version>
+	<TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+	<AssemblyName>Castle.Windsor.MsDependencyInjection.Tests</AssemblyName>
     <PackageId>Castle.Windsor.MsDependencyInjection.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -16,12 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Castle.Windsor.MsDependencyInjection.Tests.csproj
@@ -13,16 +13,25 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Castle.Windsor.MsDependencyInjection\Castle.Windsor.MsDependencyInjection.csproj" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.6.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
+	  <PackageReference Include="xunit.extensibility.core" Version="2.6.6" />
   </ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+		<PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+		<PackageReference Include="Shouldly" Version="4.0.3" />
+		<PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/Castle.Windsor.MsDependencyInjection/Castle.Windsor.MsDependencyInjection.csproj
+++ b/src/Castle.Windsor.MsDependencyInjection/Castle.Windsor.MsDependencyInjection.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.1.0</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <Version>4.2.0</Version>
+	<TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Castle.Windsor.MsDependencyInjection</AssemblyName>
     <PackageId>Castle.Windsor.MsDependencyInjection</PackageId>
     <PackageTags>Windsor;Castle;AspNetCore;DI;IoC;DNX;DependencyInjection;Extensions</PackageTags>
@@ -15,16 +15,38 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="bin\Release\net6.0\Castle.Windsor.MsDependencyInjection.pdb">
-      <PackagePath>lib/net6.0/</PackagePath>
-      <Pack>true</Pack>
-    </None>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<None Include="bin\Release\net5.0\Castle.Windsor.MsDependencyInjection.pdb">
+			<PackagePath>lib/net5.0/</PackagePath>
+			<Pack>true</Pack>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<None Include="bin\Release\net6.0\Castle.Windsor.MsDependencyInjection.pdb">
+			<PackagePath>lib/net6.0/</PackagePath>
+			<Pack>true</Pack>
+		</None>
   </ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<None Include="bin\Release\net7.0\Castle.Windsor.MsDependencyInjection.pdb">
+			<PackagePath>lib/net7.0/</PackagePath>
+			<Pack>true</Pack>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<None Include="bin\Release\net8.0\Castle.Windsor.MsDependencyInjection.pdb">
+			<PackagePath>lib/net8.0/</PackagePath>
+			<Pack>true</Pack>
+		</None>
+	</ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[7.0.0, 9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[7.0.0, 9.0.0)" />
     <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />


### PR DESCRIPTION
For better compatibility with NET 5, TargetFrameworks was implemented for NET5, NET6, NET7 and NET8.

Create a TestSuites for this target.

Create a 4.2.0 version.