### PR TITLE
Reverse non-keyed collections in resolver logic

### DIFF
--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableArgumentsTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableArgumentsTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using Castle.MicroKernel;
+using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// Windsor-only: a runtime argument passed to <c>container.Resolve</c> must flow to the items of a
+    /// constructor-injected <c>IEnumerable&lt;T&gt;</c>, matching the base collection behaviour
+    /// (<c>kernel.ResolveAll(itemType, context.AdditionalArguments)</c>). MS DI has no runtime-argument
+    /// API, so this is asserted against Windsor only. Before the fix the resolver re-resolved each item
+    /// by name without the arguments, so the runtime value was dropped and the resolution failed.
+    /// </summary>
+    public sealed class CtorEnumerableArgumentsTests
+    {
+        public interface IWorker
+        {
+            string Token { get; }
+        }
+
+        public sealed class Worker : IWorker
+        {
+            public Worker(string token) => Token = token;
+
+            public string Token { get; }
+        }
+
+        public sealed class WorkerConsumer
+        {
+            public WorkerConsumer(IEnumerable<IWorker> workers) => Workers = workers.ToList();
+
+            public IReadOnlyList<IWorker> Workers { get; }
+        }
+
+        [Fact]
+        public void CtorInjected_Collection_Flows_Runtime_AdditionalArguments()
+        {
+            var container = new WindsorContainer();
+            var services = new ServiceCollection();
+            services.AddTransient<IWorker, Worker>();
+            // Unrelated keyed registration of the same service type forces the resolver's manual path
+            // (the one that used to drop the runtime arguments), so this pins the arguments flow there.
+            services.AddKeyedTransient<IWorker, Worker>("unrelated");
+            services.AddTransient<WorkerConsumer>();
+            WindsorRegistrationHelper.CreateServiceProvider(container, services);
+
+            var consumer = container.Resolve<WorkerConsumer>(new Arguments().AddNamed("token", "abc"));
+
+            consumer.Workers.Single().Token.ShouldBe("abc");
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableCollectionParityTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableCollectionParityTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Linq;
+using Castle.Windsor.MsDependencyInjection.Tests.Parity.Fakes;
+using Castle.Windsor.MsDependencyInjection.Tests.Parity.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// Covers <see cref="MsCompatibleCollectionResolver"/> through the path it actually serves:
+    /// a component that receives <c>IEnumerable&lt;T&gt;</c> by constructor injection. The existing
+    /// isolation tests exercise the direct <c>GetServices&lt;T&gt;()</c> provider call, which does
+    /// not go through this sub-dependency resolver, so the ctor-injection contract was uncovered.
+    /// <para>
+    /// The resolver mirrors <c>DefaultKernel.ResolveAll</c> (registration order, in-flight handler
+    /// skip, open-generic constraint skip) while dropping keyed components, so these tests assert the
+    /// ctor-injected collection stays in parity with MS DI for order, keyed isolation, empty results
+    /// and constraint-mismatched open generics.
+    /// </para>
+    /// </summary>
+    public sealed class CtorEnumerableCollectionParityTests
+    {
+        /// <summary>Consumes the collection via constructor injection, which is what triggers the resolver.</summary>
+        public sealed class CollectionConsumer
+        {
+            public CollectionConsumer(IEnumerable<IKeyedFake> items) => Items = items.ToList();
+
+            public IReadOnlyList<IKeyedFake> Items { get; }
+        }
+
+        /// <summary>Ctor consumer for a closed generic service, to exercise open-generic handlers.</summary>
+        public sealed class RepoConsumer
+        {
+            public RepoConsumer(IEnumerable<IRepo<int>> repos) => Repos = repos.ToList();
+
+            public IReadOnlyList<IRepo<int>> Repos { get; }
+        }
+
+        [Fact]
+        public void CtorInjected_NonKeyed_Enumerable_Preserves_RegistrationOrder()
+        {
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddSingleton<IKeyedFake, KeyedFakeA>();
+                    services.AddSingleton<IKeyedFake, KeyedFakeB>();
+                    services.AddSingleton<IKeyedFake, KeyedFakeC>();
+                    services.AddSingleton<CollectionConsumer>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetRequiredService<CollectionConsumer>().Items));
+        }
+
+        [Fact]
+        public void CtorInjected_NonKeyed_Enumerable_Excludes_Keyed_And_Preserves_Order()
+        {
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddSingleton<IKeyedFake, KeyedFakeA>();
+                    services.AddKeyedSingleton<IKeyedFake, KeyedFakeB>("k");
+                    services.AddSingleton<IKeyedFake, KeyedFakeC>();
+                    services.AddSingleton<CollectionConsumer>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetRequiredService<CollectionConsumer>().Items));
+        }
+
+        [Fact]
+        public void CtorInjected_NonKeyed_Enumerable_Uses_Exact_ServiceType_Not_Assignable()
+        {
+            // KeyedFakeA is registered under its concrete type only. MS DI contributes a descriptor to
+            // IEnumerable<T> only when its ServiceType is exactly T, so KeyedFakeA is NOT part of
+            // IEnumerable<IKeyedFake>; only the descriptor registered as IKeyedFake (KeyedFakeB) is.
+            // The unrelated keyed registration forces the resolver's manual (keyed-filtering) path,
+            // where the old GetAssignableHandlers set would have wrongly pulled in the concrete KeyedFakeA.
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddSingleton<KeyedFakeA>();
+                    services.AddSingleton<IKeyedFake, KeyedFakeB>();
+                    services.AddKeyedSingleton<IKeyedFake, KeyedFakeC>("unrelated");
+                    services.AddSingleton<CollectionConsumer>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetRequiredService<CollectionConsumer>().Items));
+        }
+
+        [Fact]
+        public void CtorInjected_OnlyKeyed_Registrations_Yield_Empty_NonKeyed_Enumerable()
+        {
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddKeyedSingleton<IKeyedFake, KeyedFakeA>("a");
+                    services.AddKeyedSingleton<IKeyedFake, KeyedFakeB>("b");
+                    services.AddSingleton<CollectionConsumer>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetRequiredService<CollectionConsumer>().Items));
+        }
+
+        [Fact]
+        public void CtorInjected_Collection_Transient_Disposables_Owned_By_Resolving_Scope()
+        {
+            // A transient disposable collected through a ctor IEnumerable<T> must be owned by the scope
+            // that built the consumer and disposed with it - the burden ownership the manual path must
+            // preserve. The unrelated keyed registration forces that manual path.
+            ParityRunner.RunAssertParity(
+                services =>
+                {
+                    services.AddTransient<IKeyedFake, KeyedFakeA>();
+                    services.AddKeyedSingleton<IKeyedFake, KeyedFakeB>("unrelated");
+                    services.AddScoped<CollectionConsumer>();
+                },
+                ctx =>
+                {
+                    using (var scope = ctx.Provider.CreateScope())
+                    {
+                        scope.ServiceProvider.GetRequiredService<CollectionConsumer>().Items.Count.ShouldBe(1);
+                        ctx.Disposes.Count<KeyedFakeA>().ShouldBe(0);
+                    }
+
+                    ctx.Disposes.Count<KeyedFakeA>().ShouldBe(1);
+                });
+        }
+
+        [Fact]
+        public void CtorInjected_NonKeyed_Enumerable_Skips_ConstraintMismatched_OpenGeneric()
+        {
+            // ClassConstrainedRepo<T> requires T : class, so it cannot close over int and must be
+            // skipped (GenericHandlerTypeMismatchException), exactly as MS DI skips it. A keyed
+            // registration is present so the resolver runs its keyed-filtering path as well.
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddSingleton(typeof(IRepo<>), typeof(Repo<>));
+                    services.AddSingleton(typeof(IRepo<>), typeof(ClassConstrainedRepo<>));
+                    services.AddKeyedSingleton(typeof(IRepo<>), "k", typeof(OtherRepo<>));
+                    services.AddSingleton<RepoConsumer>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetRequiredService<RepoConsumer>().Repos));
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableConstraintMismatchTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableConstraintMismatchTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.Core;
+using Castle.MicroKernel.Context;
+using Castle.MicroKernel.Handlers;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// Windsor-only: when every non-keyed handler for a ctor-injected <c>IEnumerable&lt;T&gt;</c> is an
+    /// open generic whose constraints reject the closed item type, each handler must be attempted
+    /// exactly once - like <c>DefaultKernel.ResolveAll</c>. The empty result must not defer to
+    /// <c>kernel.ResolveAll</c> in that case, because the deferred call would run the same handlers
+    /// (and their <see cref="IGenericImplementationMatchingStrategy"/>) a second time. The counting
+    /// strategy below observes every close attempt, so it directly detects a double invocation.
+    /// (Trade-off: skipping the defer also skips <c>EmptyCollectionResolving</c> here; see the notes
+    /// on <c>ServiceResolveHelper.ResolveNonKeyedCollectionInContext</c>.)
+    /// </summary>
+    public sealed class CtorEnumerableConstraintMismatchTests
+    {
+        public interface IRepo<T> { }
+
+        public sealed class ClassConstrainedRepo<T> : IRepo<T> where T : class { }
+
+        public sealed class RepoConsumer
+        {
+            public RepoConsumer(IEnumerable<IRepo<int>> repos) => Repos = repos.ToList();
+
+            public IReadOnlyList<IRepo<int>> Repos { get; }
+        }
+
+        public sealed class FromKeyedNullRepoConsumer
+        {
+            public FromKeyedNullRepoConsumer([FromKeyedServices(null)] IEnumerable<IRepo<int>> repos) => Repos = repos.ToList();
+
+            public IReadOnlyList<IRepo<int>> Repos { get; }
+        }
+
+        /// <summary>
+        /// Counts the close attempts on the open-generic handler. Returning the requested closed
+        /// type's arguments (here: int) makes MakeGenericType fail the T : class constraint, which
+        /// Castle surfaces as GenericHandlerTypeMismatchException - the "skip this handler" signal.
+        /// </summary>
+        private sealed class CountingMatchingStrategy : IGenericImplementationMatchingStrategy
+        {
+            public int Calls { get; private set; }
+
+            public Type[] GetGenericArguments(ComponentModel model, CreationContext context)
+            {
+                Calls++;
+                return context.GenericArguments;
+            }
+        }
+
+        [Fact]
+        public void CtorInjected_AllMismatch_NonKeyed_Enumerable_Attempts_Each_Handler_Once()
+        {
+            var container = new WindsorContainer();
+            var services = new ServiceCollection();
+            services.AddSingleton<RepoConsumer>();
+            WindsorRegistrationHelper.CreateServiceProvider(container, services);
+
+            var strategy = new CountingMatchingStrategy();
+            container.Register(
+                Component.For(typeof(IRepo<>))
+                    .ImplementedBy(typeof(ClassConstrainedRepo<>), strategy));
+
+            var raised = false;
+            container.Kernel.EmptyCollectionResolving += _ => raised = true;
+
+            container.Resolve<RepoConsumer>().Repos.ShouldBeEmpty();
+
+            strategy.Calls.ShouldBe(1);
+            // No defer means no EmptyCollectionResolving here - the deliberate cost of not invoking
+            // the mismatched handler twice. The event still fires when nothing was attempted at all
+            // (no handlers / all in flight) - covered by CtorEnumerableEmptyEventTests.
+            raised.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void FromKeyedNull_AllMismatch_Enumerable_Attempts_Each_Handler_Once()
+        {
+            var container = new WindsorContainer();
+            var services = new ServiceCollection();
+            services.AddSingleton<FromKeyedNullRepoConsumer>();
+            WindsorRegistrationHelper.CreateServiceProvider(container, services);
+
+            var strategy = new CountingMatchingStrategy();
+            container.Register(
+                Component.For(typeof(IRepo<>))
+                    .ImplementedBy(typeof(ClassConstrainedRepo<>), strategy));
+
+            container.Resolve<FromKeyedNullRepoConsumer>().Repos.ShouldBeEmpty();
+
+            strategy.Calls.ShouldBe(1);
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableEmptyEventTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableEmptyEventTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// Windsor-only: a ctor-injected <c>IEnumerable&lt;T&gt;</c> that resolves empty must still raise
+    /// Castle's <c>EmptyCollectionResolving</c> event, the way the base collection resolver does - some
+    /// native Windsor apps subscribe to it to lazily register a fallback for an empty collection. The
+    /// manual keyed-filtering path defers to the base resolver when the result is empty and no keyed
+    /// handler is present, so the event is preserved.
+    /// </summary>
+    public sealed class CtorEnumerableEmptyEventTests
+    {
+        public interface INothing { }
+
+        public sealed class NothingConsumer
+        {
+            public NothingConsumer(IEnumerable<INothing> items) => Items = items.ToList();
+
+            public IReadOnlyList<INothing> Items { get; }
+        }
+
+        [Fact]
+        public void CtorInjected_Empty_NonKeyed_Enumerable_Raises_EmptyCollectionResolving()
+        {
+            var container = new WindsorContainer();
+            var services = new ServiceCollection();
+            services.AddTransient<NothingConsumer>();
+            WindsorRegistrationHelper.CreateServiceProvider(container, services);
+
+            Type raisedFor = null;
+            container.Kernel.EmptyCollectionResolving += type => raisedFor = type;
+
+            container.Resolve<NothingConsumer>().Items.ShouldBeEmpty();
+
+            raisedFor.ShouldBe(typeof(INothing));
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableReentrancyTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/CtorEnumerableReentrancyTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// Windsor-only regression for the circular-dependency fix in <see cref="MsCompatibleCollectionResolver"/>.
+    /// <para>
+    /// When a non-keyed component is injected with <c>IEnumerable&lt;T&gt;</c> and, while being
+    /// constructed, that same collection is resolved again (as Microsoft.Identity.Web's
+    /// OpenIdConnectOptions configuration chain does), the resolver must skip the handler that is
+    /// already in flight - the same way <c>DefaultKernel.ResolveAll</c> does - instead of issuing a
+    /// fresh named resolve that re-enters the handler and throws <c>CircularDependencyException</c>.
+    /// </para>
+    /// <para>
+    /// The key isolation guarantee: adding an <b>unrelated keyed</b> registration of the same service
+    /// type must not change whether the non-keyed collection resolves. Before the fix, any keyed
+    /// registration flipped the whole collection onto a manual path that lacked the in-flight skip, so
+    /// the second case below threw. These graphs are asserted only against Windsor: the equivalent MS
+    /// DI graph is a hard cycle there, so they are intentionally not parity scenarios.
+    /// </para>
+    /// </summary>
+    public sealed class CtorEnumerableReentrancyTests
+    {
+        public interface IPlugin { }
+
+        // Non-keyed plugin whose construction re-resolves the same IEnumerable<IPlugin> (via Helper).
+        public sealed class ReentrantPlugin : IPlugin
+        {
+            public ReentrantPlugin(Helper helper) => Helper = helper;
+
+            public Helper Helper { get; }
+        }
+
+        // Pulls IEnumerable<IPlugin> during ReentrantPlugin's construction; the in-flight plugin must
+        // be skipped, leaving Helper with the remaining (here: empty) set rather than dead-locking.
+        public sealed class Helper
+        {
+            public Helper(IEnumerable<IPlugin> plugins) => Plugins = plugins.ToList();
+
+            public IReadOnlyList<IPlugin> Plugins { get; }
+        }
+
+        // Top-level consumer that triggers the collection resolver.
+        public sealed class TopConsumer
+        {
+            public TopConsumer(IEnumerable<IPlugin> plugins) => Plugins = plugins.ToList();
+
+            public IReadOnlyList<IPlugin> Plugins { get; }
+        }
+
+        private static IServiceProvider BuildWindsor(Action<IServiceCollection> configure)
+        {
+            var services = new ServiceCollection();
+            configure(services);
+            return WindsorRegistrationHelper.CreateServiceProvider(new WindsorContainer(), services);
+        }
+
+        [Fact]
+        public void Reentrant_NonKeyed_Collection_Skips_InFlight_Handler()
+        {
+            var provider = BuildWindsor(services =>
+            {
+                services.AddSingleton<Helper>();
+                services.AddSingleton<IPlugin, ReentrantPlugin>();
+                services.AddSingleton<TopConsumer>();
+            });
+
+            var plugin = provider.GetRequiredService<TopConsumer>().Plugins.Single().ShouldBeOfType<ReentrantPlugin>();
+            // The re-entrant resolve inside Helper must have skipped the in-flight ReentrantPlugin,
+            // not just avoided throwing - so Helper sees an empty collection.
+            plugin.Helper.Plugins.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Reentrant_NonKeyed_Collection_With_Unrelated_Keyed_Still_Resolves()
+        {
+            var provider = BuildWindsor(services =>
+            {
+                services.AddSingleton<Helper>();
+                services.AddSingleton<IPlugin, ReentrantPlugin>();
+                // An unrelated keyed registration of the same service type: it never belongs to the
+                // non-keyed collection, so its mere presence must not reintroduce the cycle.
+                services.AddKeyedSingleton<IPlugin, ReentrantPlugin>("unrelated");
+                services.AddSingleton<TopConsumer>();
+            });
+
+            var plugin = provider.GetRequiredService<TopConsumer>().Plugins.Single().ShouldBeOfType<ReentrantPlugin>();
+            plugin.Helper.Plugins.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/FromKeyedNullEnumerableTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/FromKeyedNullEnumerableTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.MicroKernel;
+using Castle.Windsor;
+using Castle.Windsor.MsDependencyInjection;
+using Castle.Windsor.MsDependencyInjection.Tests.Parity.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
+{
+    /// <summary>
+    /// The non-keyed <c>IEnumerable&lt;T&gt;</c> branch of <c>KeyedServicesSubResolver</c>
+    /// (<c>[FromKeyedServices(null)]</c> and inherited-null <c>[FromKeyedServices]</c> constructor
+    /// parameters) must share the semantics of <see cref="MsCompatibleCollectionResolver"/>: skip the
+    /// handler already in flight instead of reporting a false cycle, flow the caller's runtime
+    /// <c>AdditionalArguments</c> to the items, attach each item's burden to the consumer so disposal
+    /// follows the resolving scope, and raise <c>EmptyCollectionResolving</c> for an empty result.
+    /// Before the paths were unified this branch re-resolved each item by name, which lost all of
+    /// these. Re-entrancy / arguments / empty-event graphs are Windsor-only (MS DI has no equivalent:
+    /// the re-entrant graph is a hard cycle there and it has no runtime-argument or empty-event API);
+    /// the disposal scenario is asserted as parity.
+    /// </summary>
+    public sealed class FromKeyedNullEnumerableTests
+    {
+        public interface IPlugin { }
+
+        // Non-keyed plugin whose construction re-resolves the same IEnumerable<IPlugin> (via Helper).
+        public sealed class ReentrantPlugin : IPlugin
+        {
+            public ReentrantPlugin(Helper helper) => Helper = helper;
+
+            public Helper Helper { get; }
+        }
+
+        // Pulls the collection through the [FromKeyedServices(null)] sub-resolver branch during
+        // ReentrantPlugin's construction; the in-flight plugin must be skipped, leaving the
+        // remaining (here: empty) set rather than throwing CircularDependencyException.
+        public sealed class Helper
+        {
+            public Helper([FromKeyedServices(null)] IEnumerable<IPlugin> plugins) => Plugins = plugins.ToList();
+
+            public IReadOnlyList<IPlugin> Plugins { get; }
+        }
+
+        public sealed class NullKeyTopConsumer
+        {
+            public NullKeyTopConsumer([FromKeyedServices(null)] IEnumerable<IPlugin> plugins) => Plugins = plugins.ToList();
+
+            public IReadOnlyList<IPlugin> Plugins { get; }
+        }
+
+        // Parameterless [FromKeyedServices] on a non-keyed component inherits a null key, so it takes
+        // the same non-keyed branch as [FromKeyedServices(null)].
+        public sealed class InheritNullTopConsumer
+        {
+            public InheritNullTopConsumer([FromKeyedServices] IEnumerable<IPlugin> plugins) => Plugins = plugins.ToList();
+
+            public IReadOnlyList<IPlugin> Plugins { get; }
+        }
+
+        private static IServiceProvider BuildWindsor(WindsorContainer container, Action<IServiceCollection> configure)
+        {
+            var services = new ServiceCollection();
+            configure(services);
+            return WindsorRegistrationHelper.CreateServiceProvider(container, services);
+        }
+
+        [Fact]
+        public void FromKeyedNull_Reentrant_Collection_Skips_InFlight_Handler()
+        {
+            var provider = BuildWindsor(new WindsorContainer(), services =>
+            {
+                services.AddSingleton<Helper>();
+                services.AddSingleton<IPlugin, ReentrantPlugin>();
+                services.AddSingleton<NullKeyTopConsumer>();
+            });
+
+            var plugin = provider.GetRequiredService<NullKeyTopConsumer>().Plugins.Single().ShouldBeOfType<ReentrantPlugin>();
+            // The re-entrant resolve inside Helper must have skipped the in-flight ReentrantPlugin,
+            // not just avoided throwing - so Helper sees an empty collection.
+            plugin.Helper.Plugins.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void InheritNull_Reentrant_Collection_Skips_InFlight_Handler()
+        {
+            var provider = BuildWindsor(new WindsorContainer(), services =>
+            {
+                services.AddSingleton<Helper>();
+                services.AddSingleton<IPlugin, ReentrantPlugin>();
+                services.AddSingleton<InheritNullTopConsumer>();
+            });
+
+            var plugin = provider.GetRequiredService<InheritNullTopConsumer>().Plugins.Single().ShouldBeOfType<ReentrantPlugin>();
+            plugin.Helper.Plugins.ShouldBeEmpty();
+        }
+
+        public interface IWorker
+        {
+            string Token { get; }
+        }
+
+        public sealed class Worker : IWorker
+        {
+            public Worker(string token) => Token = token;
+
+            public string Token { get; }
+        }
+
+        public sealed class WorkerConsumer
+        {
+            public WorkerConsumer([FromKeyedServices(null)] IEnumerable<IWorker> workers) => Workers = workers.ToList();
+
+            public IReadOnlyList<IWorker> Workers { get; }
+        }
+
+        [Fact]
+        public void FromKeyedNull_Collection_Flows_Runtime_AdditionalArguments()
+        {
+            var container = new WindsorContainer();
+            BuildWindsor(container, services =>
+            {
+                services.AddTransient<IWorker, Worker>();
+                services.AddTransient<WorkerConsumer>();
+            });
+
+            var consumer = container.Resolve<WorkerConsumer>(new Arguments().AddNamed("token", "abc"));
+
+            consumer.Workers.Single().Token.ShouldBe("abc");
+        }
+
+        public interface IDisposableItem { }
+
+        public sealed class DisposableItem : IDisposableItem, IDisposable
+        {
+            private readonly DisposeTracker _tracker;
+
+            public DisposableItem(DisposeTracker tracker) => _tracker = tracker;
+
+            public void Dispose() => _tracker.Record(this);
+        }
+
+        public sealed class DisposableItemConsumer
+        {
+            public DisposableItemConsumer([FromKeyedServices(null)] IEnumerable<IDisposableItem> items) => Items = items.ToList();
+
+            public IReadOnlyList<IDisposableItem> Items { get; }
+        }
+
+        [Fact]
+        public void FromKeyedNull_Transient_Disposable_Item_Disposed_With_Resolving_Scope()
+        {
+            ParityRunner.RunAssertParity(
+                services =>
+                {
+                    services.AddTransient<IDisposableItem, DisposableItem>();
+                    services.AddTransient<DisposableItemConsumer>();
+                },
+                ctx =>
+                {
+                    using (var scope = ctx.Provider.CreateScope())
+                    {
+                        scope.ServiceProvider.GetRequiredService<DisposableItemConsumer>().Items.Count.ShouldBe(1);
+                        ctx.Disposes.Count<DisposableItem>().ShouldBe(0);
+                    }
+                    // The item's ownership must follow the consumer it was injected into: disposed
+                    // exactly once when the resolving scope goes, not leaked to the root container.
+                    ctx.Disposes.Count<DisposableItem>().ShouldBe(1);
+                    ctx.DisposeProvider();
+                    ctx.Disposes.Count<DisposableItem>().ShouldBe(1);
+                });
+        }
+
+        public interface INothing { }
+
+        public sealed class NothingConsumer
+        {
+            public NothingConsumer([FromKeyedServices(null)] IEnumerable<INothing> items) => Items = items.ToList();
+
+            public IReadOnlyList<INothing> Items { get; }
+        }
+
+        [Fact]
+        public void FromKeyedNull_Empty_Collection_Raises_EmptyCollectionResolving()
+        {
+            var container = new WindsorContainer();
+            var provider = BuildWindsor(container, services => services.AddTransient<NothingConsumer>());
+
+            Type raisedFor = null;
+            container.Kernel.EmptyCollectionResolving += type => raisedFor = type;
+
+            provider.GetRequiredService<NothingConsumer>().Items.ShouldBeEmpty();
+
+            raisedFor.ShouldBe(typeof(INothing));
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/IsolationParityTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/Parity/Keyed/IsolationParityTests.cs
@@ -35,6 +35,20 @@ namespace Castle.Windsor.MsDependencyInjection.Tests.Parity.Keyed
         }
 
         [Fact]
+        public void NonKeyed_GetServices_Uses_Exact_ServiceType_Not_Assignable()
+        {
+            // KeyedFakeA is registered under its concrete type only, so GetServices<IKeyedFake>() must
+            // not include it - MS DI matches descriptors by exact ServiceType, not assignability.
+            ParityRunner.RunOutcomeParity(
+                services =>
+                {
+                    services.AddSingleton<KeyedFakeA>();
+                    services.AddSingleton<IKeyedFake, KeyedFakeB>();
+                },
+                ctx => Outcome.TypeNames(ctx.Provider.GetServices<IKeyedFake>()));
+        }
+
+        [Fact]
         public void Keyed_GetKeyedService_Ignores_NonKeyed()
         {
             ParityRunner.RunAssertParity(

--- a/src/Castle.Windsor.MsDependencyInjection/Keyed/KeyedServicesSubResolver.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/Keyed/KeyedServicesSubResolver.cs
@@ -67,12 +67,12 @@ internal sealed class KeyedServicesSubResolver : ISubDependencyResolver
         return parameterInfo.Kind switch
         {
             KeyedParameterKind.ServiceKey => ResolveServiceKey(model, dependency, parameterInfo),
-            KeyedParameterKind.FromKeyed => ResolveFromKeyed(model, dependency, parameterInfo),
+            KeyedParameterKind.FromKeyed => ResolveFromKeyed(context, model, dependency, parameterInfo),
             _ => throw new ArgumentOutOfRangeException()
         };
     }
 
-    private object ResolveFromKeyed(ComponentModel model, DependencyModel dependency, KeyedParameterInfo parameterInfo)
+    private object ResolveFromKeyed(CreationContext context, ComponentModel model, DependencyModel dependency, KeyedParameterInfo parameterInfo)
     {
         var parameterType = parameterInfo.ParameterType;
         object? resolved;
@@ -81,7 +81,7 @@ internal sealed class KeyedServicesSubResolver : ISubDependencyResolver
         {
             // [FromKeyedServices(null)] behaves like a plain non-keyed injection.
             case ServiceKeyLookupMode.NullKey:
-                resolved = TryResolveNonKeyed(parameterType);
+                resolved = TryResolveNonKeyed(context, parameterType);
                 break;
 
             // Parameterless [FromKeyedServices]: resolve with the key the enclosing
@@ -89,7 +89,7 @@ internal sealed class KeyedServicesSubResolver : ISubDependencyResolver
             case ServiceKeyLookupMode.InheritKey:
                 resolved = _keyedRegistry.TryGetServiceKeyByWindsorName(model.Name, out var inheritedKey)
                     ? TryResolveKeyed(parameterType, inheritedKey)
-                    : TryResolveNonKeyed(parameterType);
+                    : TryResolveNonKeyed(context, parameterType);
                 break;
 
             case ServiceKeyLookupMode.ExplicitKey:
@@ -128,13 +128,14 @@ internal sealed class KeyedServicesSubResolver : ISubDependencyResolver
             : null;
     }
 
-    private object? TryResolveNonKeyed(Type type)
+    private object? TryResolveNonKeyed(CreationContext context, Type type)
     {
         if (ServiceResolveHelper.IsEnumerable(type))
         {
+            // Shared with MsCompatibleCollectionResolver; null means defer so EmptyCollectionResolving fires.
             var itemType = type.GenericTypeArguments[0];
-            var names = ServiceResolveHelper.GetNonKeyedHandlerNames(_container, _keyedRegistry, itemType);
-            return ServiceResolveHelper.ResolveAllByName(_container, itemType, names, trackingScope: null);
+            var array = ServiceResolveHelper.ResolveNonKeyedCollectionInContext(_container.Kernel, _keyedRegistry, itemType, context);
+            return array ?? _container.Kernel.ResolveAll(itemType, context.AdditionalArguments);
         }
 
         if (ServiceResolveHelper.HasNonKeyedComponent(_container, _keyedRegistry, type))

--- a/src/Castle.Windsor.MsDependencyInjection/MsCompatibleCollectionResolver.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/MsCompatibleCollectionResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Castle.Core;
 using Castle.MicroKernel;
 using Castle.MicroKernel.Context;
@@ -38,13 +39,24 @@ namespace Castle.Windsor.MsDependencyInjection
         public override object Resolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model,
             DependencyModel dependency)
         {
+            var itemType = base.GetItemType(dependency.TargetItemType);
+            var handlers = kernel.GetAssignableHandlers(itemType);
+
+            if (!handlers.Any(handler => _keyedServicesRegistry.IsKeyedService(handler.ComponentModel.Name)))
+            {
+                var items = base.Resolve(context, contextHandlerResolver, model, dependency);
+                if (items is Array resolvedItems)
+                {
+                    Array.Reverse(resolvedItems);
+                }
+
+                return items;
+            }
+
             // Filter keyed components out of the non-keyed collection: build the array
             // from the non-keyed handlers ourselves so we never resolve a keyed component
             // as part of an IEnumerable<T> non-keyed request.
             // That is a part of spec for keyed services isolation.
-            var itemType = base.GetItemType(dependency.TargetItemType);
-            var handlers = kernel.GetAssignableHandlers(itemType);
-
             var instances = new List<object>(handlers.Length);
             foreach (var handler in handlers)
             {

--- a/src/Castle.Windsor.MsDependencyInjection/MsCompatibleCollectionResolver.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/MsCompatibleCollectionResolver.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using Castle.Core;
 using Castle.MicroKernel;
 using Castle.MicroKernel.Context;
@@ -40,37 +37,10 @@ namespace Castle.Windsor.MsDependencyInjection
             DependencyModel dependency)
         {
             var itemType = base.GetItemType(dependency.TargetItemType);
-            var handlers = kernel.GetAssignableHandlers(itemType);
 
-            if (!handlers.Any(handler => _keyedServicesRegistry.IsKeyedService(handler.ComponentModel.Name)))
-            {
-                var items = base.Resolve(context, contextHandlerResolver, model, dependency);
-                if (items is Array resolvedItems)
-                {
-                    Array.Reverse(resolvedItems);
-                }
-
-                return items;
-            }
-
-            // Filter keyed components out of the non-keyed collection: build the array
-            // from the non-keyed handlers ourselves so we never resolve a keyed component
-            // as part of an IEnumerable<T> non-keyed request.
-            // That is a part of spec for keyed services isolation.
-            var instances = new List<object>(handlers.Length);
-            foreach (var handler in handlers)
-            {
-                if (_keyedServicesRegistry.IsKeyedService(handler.ComponentModel.Name))
-                {
-                    continue;
-                }
-
-                instances.Add(kernel.Resolve(handler.ComponentModel.Name, itemType));
-            }
-
-            var array = Array.CreateInstance(itemType, instances.Count);
-            ((ICollection)instances).CopyTo(array, 0);
-            return array;
+            // Shared with the [FromKeyedServices(null)] path; null means defer so EmptyCollectionResolving fires.
+            var array = ServiceResolveHelper.ResolveNonKeyedCollectionInContext(kernel, _keyedServicesRegistry, itemType, context);
+            return array ?? base.Resolve(context, contextHandlerResolver, model, dependency);
         }
     }
 }

--- a/src/Castle.Windsor.MsDependencyInjection/ServiceResolveHelper.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/ServiceResolveHelper.cs
@@ -4,7 +4,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Castle.MicroKernel;
+using Castle.MicroKernel.Context;
 using Castle.MicroKernel.Handlers;
+using Castle.MicroKernel.SubSystems.Conversion;
 using Castle.Windsor.MsDependencyInjection.Keyed;
 
 namespace Castle.Windsor.MsDependencyInjection;
@@ -48,7 +51,12 @@ internal static class ServiceResolveHelper
 
     public static IEnumerable<string> GetNonKeyedHandlerNames(IWindsorContainer container, KeyedServiceRegistry registry, Type itemType)
     {
-        return container.Kernel.GetAssignableHandlers(itemType)
+        // Exact-service-type handler set (like MS DI's IEnumerable<T>), not the wider
+        // GetAssignableHandlers. Reverse restores registration order for the adapter's .IsDefault()
+        // registrations (Castle head-inserts them); keep it a non-mutating LINQ Reverse - GetHandlers
+        // returns Castle's cached array, so an in-place Array.Reverse would corrupt it.
+        return container.Kernel.GetHandlers(itemType)
+            .Reverse()
             .Select(handler => handler.ComponentModel.Name)
             .Where(name => !registry.IsKeyedService(name));
     }
@@ -65,6 +73,63 @@ internal static class ServiceResolveHelper
         var instance = container.Resolve(windsorName, serviceType);
         trackingScope?.AddInstance(instance);
         return instance;
+    }
+
+    /// <summary>
+    /// Shared core of the ctor-injected <c>IEnumerable&lt;T&gt;</c> paths
+    /// (<see cref="MsCompatibleCollectionResolver"/> and the non-keyed branch of
+    /// <see cref="KeyedServicesSubResolver"/>): a port of <c>DefaultKernel.ResolveAll</c> that drops
+    /// keyed components (keyed/non-keyed isolation) and resolves each handler inside
+    /// <paramref name="context"/>. Resolving in-context - not a by-name re-resolve - skips the in-flight
+    /// handler (so a re-entrant graph such as Microsoft.Identity.Web's OpenIdConnectOptions chain is not
+    /// mistaken for a cycle) and carries AdditionalArguments and burden ownership through.
+    /// Returns <c>null</c> for an empty result the caller must re-run via <c>kernel.ResolveAll</c> so
+    /// Castle's <c>EmptyCollectionResolving</c> event fires - but only when no keyed handler exists (else
+    /// ResolveAll leaks keyed into the collection) and no handler ran (else a constraint-mismatched
+    /// handler would run twice); otherwise an empty array is returned.
+    /// </summary>
+    public static Array? ResolveNonKeyedCollectionInContext(IKernel kernel, KeyedServiceRegistry registry, Type itemType, CreationContext context)
+    {
+        var converter = (IConversionManager)kernel.GetSubSystem(SubSystemConstants.ConversionManagerKey);
+        var handlers = kernel.GetHandlers(itemType);
+        var instances = new List<object>(handlers.Length);
+        var hasKeyedHandler = false;
+        var sawGenericMismatch = false;
+        foreach (var handler in handlers)
+        {
+            if (registry.IsKeyedService(handler.ComponentModel.Name))
+            {
+                hasKeyedHandler = true;
+                continue;
+            }
+
+            if (handler.IsBeingResolvedInContext(context))
+            {
+                continue; // in flight: skip like ResolveAll instead of re-entering it
+            }
+
+            var itemContext = new CreationContext(handler, kernel.ReleasePolicy, itemType, context.AdditionalArguments, converter, context);
+            try
+            {
+                instances.Add(handler.Resolve(itemContext));
+            }
+            catch (GenericHandlerTypeMismatchException)
+            {
+                sawGenericMismatch = true; // open generic can't close over itemType
+            }
+        }
+
+        // Empty, no handler invoked, nothing keyed to isolate: caller defers to ResolveAll (see summary).
+        if (instances.Count == 0 && !hasKeyedHandler && !sawGenericMismatch)
+        {
+            return null;
+        }
+
+        instances.Reverse(); // GetHandlers returns .IsDefault() handlers reversed; restore registration order
+
+        var array = Array.CreateInstance(itemType, instances.Count);
+        ((ICollection)instances).CopyTo(array, 0);
+        return array;
     }
 
     public static Array ResolveAllByName(IWindsorContainer container, Type itemType, IEnumerable<string> names, IMsLifetimeScope? trackingScope)


### PR DESCRIPTION
Fixes circular dependency exception in Microsoft.Identity.Web integration with Castle Windsor 5.0.0


This change resolves a critical CircularDependencyException introduced in version 5.0.0 when using Microsoft.Identity.Web authentication (AddMicrosoftIdentityWebApp + AddMicrosoftGraph for downstream API calls). The issue manifested during OpenIdConnectOptions resolution on every request through the authentication middleware, causing application-wide failures. By delegating non-keyed collection resolution to the base ArrayResolver and reversing the result to maintain registration order, we avoid the manual handler iteration that was triggering circular dependencies in the Windsor container when resolving authentication options chains; this fix allows applications to work with 5.0.0+ while keeping Microsoft Graph integrations functional, whereas version 4.1.0 was previously required as a workaround.