### PR TITLE
Key keyed-parameter metadata by metadata token and position to fix race condition

### DIFF
--- a/src/Castle.Windsor.MsDependencyInjection.Tests/ParameterInfoGenerationTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/ParameterInfoGenerationTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Castle.Windsor.MsDependencyInjection.Tests.Parity.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Castle.Windsor.MsDependencyInjection.Tests
+{
+    /// <summary>
+    /// The runtime materializes <see cref="ParameterInfo"/> arrays lazily and without
+    /// synchronization (<c>m_parameters ??= ...</c> in <c>RuntimeConstructorInfo</c>), so threads
+    /// racing the first <see cref="MethodBase.GetParameters"/> call can observe different
+    /// ParameterInfo generations. Keyed-parameter metadata must therefore not rely on
+    /// ParameterInfo reference identity. These tests force a fresh generation deterministically
+    /// instead of racing threads.
+    /// </summary>
+    public sealed class ParameterInfoGenerationTests
+    {
+        [Fact]
+        public void ServiceKey_Injection_Survives_ParameterInfo_Regeneration()
+        {
+            var services = new ServiceCollection();
+            services.AddKeyedSingleton<StringKeyConsumer>("k1");
+            services.AddKeyedSingleton<StringKeyConsumer>("k2");
+
+            var sp = WindsorRegistrationHelper.CreateServiceProvider(new WindsorContainer(), services);
+
+            // Primes the adapter's keyed-parameter metadata cache with the current
+            // ParameterInfo generation.
+            sp.GetRequiredKeyedService<StringKeyConsumer>("k1").Key.ShouldBe("k1");
+
+            ForceFreshParameterInfoGeneration(typeof(StringKeyConsumer));
+
+            // The cached metadata must still match parameters of the new generation.
+            sp.GetRequiredKeyedService<StringKeyConsumer>("k2").Key.ShouldBe("k2");
+
+            (sp as IDisposable)?.Dispose();
+        }
+
+        /// <summary>
+        /// With a reference-identity metadata cache, a fresh ParameterInfo generation makes the
+        /// keyed sub-resolver decline and Windsor silently injects the non-keyed
+        /// <see cref="KeyedFakeA"/> instead of the requested keyed <see cref="KeyedFakeB"/>.
+        /// </summary>
+        [Fact]
+        public void FromKeyedServices_Injection_Survives_ParameterInfo_Regeneration()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<Parity.Infrastructure.DisposeTracker>();
+            services.AddSingleton<IKeyedFake, KeyedFakeA>();
+            services.AddKeyedSingleton<IKeyedFake, KeyedFakeB>("k");
+            services.AddTransient<FromKeyedCtorConsumer>();
+
+            var sp = WindsorRegistrationHelper.CreateServiceProvider(new WindsorContainer(), services);
+
+            sp.GetRequiredService<FromKeyedCtorConsumer>().Dep.ShouldBeOfType<KeyedFakeB>();
+
+            ForceFreshParameterInfoGeneration(typeof(FromKeyedCtorConsumer));
+
+            sp.GetRequiredService<FromKeyedCtorConsumer>().Dep.ShouldBeOfType<KeyedFakeB>();
+
+            (sp as IDisposable)?.Dispose();
+        }
+
+        /// <summary>
+        /// Simulates losing the GetParameters first-touch race: resets the runtime's lazy
+        /// parameter cache so the next call mints fresh <see cref="ParameterInfo"/> instances.
+        /// </summary>
+        private static void ForceFreshParameterInfoGeneration(Type type)
+        {
+            foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var oldGeneration = ctor.GetParameters();
+                if (oldGeneration.Length == 0)
+                {
+                    continue;
+                }
+
+                var parametersField = ctor.GetType().GetField("m_parameters", BindingFlags.Instance | BindingFlags.NonPublic);
+                parametersField.ShouldNotBeNull(
+                    "RuntimeConstructorInfo no longer has an 'm_parameters' field; " +
+                    "re-verify how this runtime caches ParameterInfo and update this test.");
+
+                parametersField.SetValue(ctor, null);
+
+                // Sanity-check the premise: the next call must return different instances.
+                ctor.GetParameters()[0].ShouldNotBeSameAs(oldGeneration[0]);
+            }
+        }
+    }
+}

--- a/src/Castle.Windsor.MsDependencyInjection.Tests/ParameterInfoGenerationTests.cs
+++ b/src/Castle.Windsor.MsDependencyInjection.Tests/ParameterInfoGenerationTests.cs
@@ -65,6 +65,35 @@ namespace Castle.Windsor.MsDependencyInjection.Tests
         }
 
         /// <summary>
+        /// The keyed parameter here sits at constructor position 1, not 0, so this exercises the
+        /// position-indexed slot mapping directly: an incorrect position-to-slot mapping (an
+        /// off-by-one, or always reading slot 0) would still pass the position-0 tests above but
+        /// fail here. The consumer and its plain dependency are types nested in this test class, so
+        /// the reflection reset of the runtime parameter cache cannot disturb fakes shared with
+        /// other (parallel) test classes.
+        /// </summary>
+        [Fact]
+        public void FromKeyedServices_At_NonZero_Position_Survives_ParameterInfo_Regeneration()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<Parity.Infrastructure.DisposeTracker>();
+            services.AddSingleton<PlainDependency>();
+            services.AddSingleton<IKeyedFake, KeyedFakeA>();
+            services.AddKeyedSingleton<IKeyedFake, KeyedFakeB>("k");
+            services.AddTransient<PositionOneKeyedConsumer>();
+
+            var sp = WindsorRegistrationHelper.CreateServiceProvider(new WindsorContainer(), services);
+
+            sp.GetRequiredService<PositionOneKeyedConsumer>().Dep.ShouldBeOfType<KeyedFakeB>();
+
+            ForceFreshParameterInfoGeneration(typeof(PositionOneKeyedConsumer));
+
+            sp.GetRequiredService<PositionOneKeyedConsumer>().Dep.ShouldBeOfType<KeyedFakeB>();
+
+            (sp as IDisposable)?.Dispose();
+        }
+
+        /// <summary>
         /// Simulates losing the GetParameters first-touch race: resets the runtime's lazy
         /// parameter cache so the next call mints fresh <see cref="ParameterInfo"/> instances.
         /// </summary>
@@ -85,9 +114,31 @@ namespace Castle.Windsor.MsDependencyInjection.Tests
 
                 parametersField.SetValue(ctor, null);
 
-                // Sanity-check the premise: the next call must return different instances.
-                ctor.GetParameters()[0].ShouldNotBeSameAs(oldGeneration[0]);
+                // Sanity-check the premise: the next call must mint a fresh instance for every
+                // position, so a test asserting on a non-zero position relies on a real regeneration.
+                var newGeneration = ctor.GetParameters();
+                for (var i = 0; i < oldGeneration.Length; i++)
+                {
+                    newGeneration[i].ShouldNotBeSameAs(oldGeneration[i]);
+                }
             }
+        }
+
+        public sealed class PlainDependency
+        {
+        }
+
+        public sealed class PositionOneKeyedConsumer
+        {
+            public PositionOneKeyedConsumer(PlainDependency plain, [FromKeyedServices("k")] IKeyedFake dep)
+            {
+                Plain = plain;
+                Dep = dep;
+            }
+
+            public PlainDependency Plain { get; }
+
+            public IKeyedFake Dep { get; }
         }
     }
 }

--- a/src/Castle.Windsor.MsDependencyInjection/Keyed/TypeKeyedMetadataRegistry.cs
+++ b/src/Castle.Windsor.MsDependencyInjection/Keyed/TypeKeyedMetadataRegistry.cs
@@ -12,6 +12,13 @@ namespace Castle.Windsor.MsDependencyInjection.Keyed;
 
 /// <summary>
 /// Service to inspect type constructors and return information about keyed parameters.
+/// <para>
+/// Entries are keyed by constructor metadata token and parameter position, not by
+/// <see cref="ParameterInfo"/> reference: the runtime materializes ParameterInfo arrays lazily
+/// and without synchronization, so threads racing the first <see cref="MethodBase.GetParameters"/>
+/// call can observe different instances for the same parameter. Token and position are stable
+/// across those generations.
+/// </para>
 /// </summary>
 internal sealed class TypeKeyedMetadataRegistry
 {
@@ -43,48 +50,79 @@ internal sealed class TypeKeyedMetadataRegistry
 
         static TypeKeyedMetadata BuildTypeMetadata(Type type)
         {
-            Dictionary<ParameterInfo, KeyedParameterInfo>? metadata = null;
+            Dictionary<int, KeyedParameterInfo?[]>? metadata = null;
 
             foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
             {
-                foreach (var parameter in ctor.GetParameters())
-                {
-                    var fromKeyed = parameter.GetCustomAttribute<FromKeyedServicesAttribute>();
-                    if (fromKeyed != null)
-                    {
-                        metadata ??= new();
-                        metadata.Add(parameter, new KeyedParameterInfo(
-                            KeyedParameterKind.FromKeyed,
-                            fromKeyed.LookupMode,
-                            fromKeyed.Key,
-                            parameter.ParameterType));
-                        continue;
-                    }
+                var parameters = ctor.GetParameters();
+                KeyedParameterInfo?[]? slots = null;
 
-                    if (parameter.IsDefined(typeof(ServiceKeyAttribute), inherit: true))
+                foreach (var parameter in parameters)
+                {
+                    var info = InspectParameter(parameter);
+                    if (info != null)
                     {
-                        metadata ??= new();
-                        metadata.Add(parameter, new KeyedParameterInfo(
-                            KeyedParameterKind.ServiceKey,
-                            ServiceKeyLookupMode.InheritKey,
-                            null,
-                            parameter.ParameterType));
+                        slots ??= new KeyedParameterInfo?[parameters.Length];
+                        slots[parameter.Position] = info;
                     }
+                }
+
+                if (slots != null)
+                {
+                    metadata ??= new();
+                    metadata.Add(ctor.MetadataToken, slots);
                 }
             }
 
             return new TypeKeyedMetadata(metadata?.ToFrozenDictionary());
         }
+
+        static KeyedParameterInfo? InspectParameter(ParameterInfo parameter)
+        {
+            var fromKeyed = parameter.GetCustomAttribute<FromKeyedServicesAttribute>();
+            if (fromKeyed != null)
+            {
+                return new KeyedParameterInfo(
+                    KeyedParameterKind.FromKeyed,
+                    fromKeyed.LookupMode,
+                    fromKeyed.Key,
+                    parameter.ParameterType);
+            }
+
+            if (parameter.IsDefined(typeof(ServiceKeyAttribute), inherit: true))
+            {
+                return new KeyedParameterInfo(
+                    KeyedParameterKind.ServiceKey,
+                    ServiceKeyLookupMode.InheritKey,
+                    null,
+                    parameter.ParameterType);
+            }
+
+            return null;
+        }
     }
 
-    private sealed record TypeKeyedMetadata(FrozenDictionary<ParameterInfo, KeyedParameterInfo>? Metadata)
+    private sealed record TypeKeyedMetadata(FrozenDictionary<int, KeyedParameterInfo?[]>? Metadata)
     {
         public bool HasKeyedParameters => Metadata != null;
 
         public bool TryGetParameter(ParameterInfo parameter, [NotNullWhen(true)] out KeyedParameterInfo? info)
         {
             info = null;
-            return Metadata?.TryGetValue(parameter, out info) == true;
+
+            if (Metadata == null || parameter.Member is not ConstructorInfo ctor)
+            {
+                return false;
+            }
+
+            if (!Metadata.TryGetValue(ctor.MetadataToken, out var slots)
+                || (uint)parameter.Position >= (uint)slots.Length)
+            {
+                return false;
+            }
+
+            info = slots[parameter.Position];
+            return info != null;
         }
     }
 }


### PR DESCRIPTION
Fixes #51.

`TypeKeyedMetadataRegistry` cached keyed-parameter metadata in a `FrozenDictionary` keyed by `ParameterInfo` reference. The runtime materializes a constructor's `ParameterInfo` array lazily and without synchronization (`m_parameters ??= ...` in `RuntimeConstructorInfo`), so threads racing the first `GetParameters()` call observe different instances for the same logical parameter. A cache populated by the losing generation then misses every later lookup for that type:

- `[ServiceKey]` parameters fail activation with `DependencyResolverException` ("Could not resolve non-optional dependency ...").
- `[FromKeyedServices]` parameters silently fall back to the non-keyed default registration and inject the wrong service.

### Change

Key the per-constructor metadata by `ConstructorInfo.MetadataToken` and slot parameters by `ParameterInfo.Position`. Both are value-stable across `ParameterInfo` generations, removing the reference-identity dependence entirely. No public-surface changes.

### Tests

`ParameterInfoGenerationTests` reproduces both failure modes deterministically: it primes the metadata cache, then resets the runtime's lazy parameter cache via reflection so the next `GetParameters()` call mints a fresh generation, exactly the state a lost first-touch race produces. Both tests fail on master and pass with this change. All 334 existing tests pass.
